### PR TITLE
Fix comparison and adjustableNumbers arguments

### DIFF
--- a/addon/components/color-picker.js
+++ b/addon/components/color-picker.js
@@ -23,7 +23,7 @@ export default Component.extend({
       disabled: this.get('disabled') || false,
 
       // If set to false it would directly apply the selected color on the button and preview.
-      comparison: this.get('comparison') || true,
+      comparison: this.get('comparison') !== false,
 
       // Default color
       default: this.get('value') || this.get('default') || 'fff',
@@ -48,7 +48,7 @@ export default Component.extend({
 
       // Enables the ability to change numbers in an input field with the scroll-wheel.
       // To use it set the cursor on a position where a number is and scroll, use ctrl to make steps of five
-      adjustableNumbers: this.get('adjustableNumbers') || true,
+      adjustableNumbers: this.get('adjustableNumbers') !== false,
 
       strings: {
         save: this.get('saveLabel') || 'Save',

--- a/tests/integration/components/color-picker-test.js
+++ b/tests/integration/components/color-picker-test.js
@@ -36,6 +36,13 @@ module('Integration | Component | color-picker', function(hooks) {
     assert.notOk(this.element.querySelector('.pcr-button').className.includes('disabled'));
   });
 
+  test('it applies the comparison property', async function(assert) {
+    await render(hbs`{{color-picker comparison=false}}`);
+    await sleep(1000);
+
+    assert.equal(this.element.querySelector('.pcr-button').style.transition, 'none 0s ease 0s');
+  });
+
   test('it applies the default value', async function(assert) {
     await render(hbs`{{color-picker default="#333"}}`);
     await sleep(1000);


### PR DESCRIPTION
The `|| true` here doesn't work  when a value of `false` is passed in.